### PR TITLE
invoke lambda function in pixel handler for #35

### DIFF
--- a/lib/app_web/controllers/sent_controller.ex
+++ b/lib/app_web/controllers/sent_controller.ex
@@ -130,6 +130,15 @@ defmodule AppWeb.SentController do
   end
 
   def pixel(conn, _params) do
+    # warm up the lambda function so emails are sent instantly!
+    payload = %{"ping" => :os.system_time(:millisecond), key: "ping"}
+    # IO.inspect(payload, label: "payload ping/2:151")
+    # see: https://github.com/dwyl/elixir-invoke-lambda-example
+    lambda = System.get_env("AWS_LAMBDA_FUNCTION")
+    ExAws.Lambda.invoke(lambda, payload, "no_context")
+    |> ExAws.request(region: System.get_env("AWS_REGION"))
+    |> IO.inspect(label: "ExAws.Lambda ping response")
+
     conn # instruct browser not to cache the image
     |> put_resp_header("cache-control", "no-store, private")
     |> put_resp_header("pragma", "no-cache")

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule App.MixProject do
   def project do
     [
       app: :app,
-      version: "1.0.0",
+      version: "1.0.1",
       elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),


### PR DESCRIPTION
This PR addresses issue #35 
Will speed up sending email when the person authenticates or registers. 🚀 

The way you can _visually_ check that this is working is by visiting: https://dwylauth.herokuapp.com
<img width="796" alt="auth-waiting-for-email" src="https://user-images.githubusercontent.com/194400/81489837-6cf2cd00-9272-11ea-86cd-d32c9d6263d4.png">

It does not "block" the UI in the Auth App it just makes the request for the "pixel" in the background.

The point is to "Wake" the https://dwylmail.herokuapp.com App so that after successfully authenticating with the Auth app, the email is sent as fast as possible. If you open the Email dashboard in a different tab you'll notice that it loads _instantly_:

![image](https://user-images.githubusercontent.com/194400/81489844-84ca5100-9272-11ea-9b98-b00b1bf3afa4.png)

Obviously this is a stop gap until we deploy all our apps to VPS: https://github.com/dwyl/learn-devops/issues/59